### PR TITLE
build: temporarily change the version of jest-dom from ^6.4.3 to 6.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/jest-dom": "6.4.2",
     "@testing-library/react": "^15.0.3",
     "@testing-library/user-event": "^14.5.2",
     "@types/node": "^20.12.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 9.0.1
     devDependencies:
       '@testing-library/jest-dom':
-        specifier: ^6.4.2
+        specifier: 6.4.2
         version: 6.4.2(vitest@1.5.0(@types/node@20.12.7)(jsdom@24.0.0)(sass@1.75.0))
       '@testing-library/react':
         specifier: ^15.0.3


### PR DESCRIPTION
- jest-dom v6.4.3 has esm relevant issue, so it makes the test to be failed.
- someone has already made the GitHub issue and PR to fix, so fix the version to 6.4.2 temporarily.
  - https://github.com/testing-library/jest-dom/pull/599